### PR TITLE
Generate Backtest Graphs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+# Description ✍️
+
+Write here the changes proposed on this Pull Request.
+
+
+# Overview 🔍
+
+Overview of the feature if possible (screenshot, gif, etc)
+
+
+# Checks ☑️
+
+- [ ] What I did 1
+- [ ] What I did 2

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Também existem pequenas adaptações nestas estratégias. Elas estão presentes
   * pyfolio
   * click
   * tabulate
+  * matplotlib
 
 
 # Como usar 🎯

--- a/bovespa/backtest.py
+++ b/bovespa/backtest.py
@@ -21,11 +21,11 @@
 # importlib.reload(backtest)
 # backtest.run(tickers, start, end=time.strftime("%Y-%m-%d"))
 
-import yfinance as yf
-import pyfolio as pf
-
 import warnings
 warnings.filterwarnings('ignore')
+
+import yfinance as yf
+import pyfolio as pf
 
 import click
 import time
@@ -86,14 +86,14 @@ def run_all(start, tickers):
   run(manada, start)
   
   click.secho(f"\nRunning Chosen Backtest {tickers}", fg='black', bg='white', bold=True)
-  return run(tickers, start)
+  run(tickers, start)
 
 # Execute the backtest from the provided start...end range and using the provided tickers
 # The default value for end is the today's date
 # Usage...
 # run(start='2015-04-05', tickers=['ABEV3', 'EGIE3', 'WEGE3', 'ITUB3', 'MDIA3', 'GRND3', 'ODPV3', 'ENBR3', 'PSSA3', 'FLRY3'])
 # run(start='2015-04-05', end='2016-04-05', tickers=['ABEV3', 'EGIE3', 'WEGE3', 'ITUB3', 'MDIA3', 'GRND3', 'ODPV3', 'ENBR3', 'PSSA3', 'FLRY3'])
-def run(tickers, start, end=time.strftime("%Y-%m-%d")):
+def run(tickers, start, end=time.strftime("%Y-%m-%d"), display=False):
   # end = next_year(start)
   tickers = list(map(lambda t: t + '.SA', tickers)) # Add '.SA' on the ending of the tickers
   tickers += ['^BVSP'] # Add Ibovespa index to tickers
@@ -119,10 +119,10 @@ def run(tickers, start, end=time.strftime("%Y-%m-%d")):
   click.secho(f"Montante Inicial: 10.000,00", fg='red', bold=True)
   click.secho(f"Montante Final: {commalize(str(montante))}", fg='blue', bold=True)
   click.secho(f"Valorização: {'{0:.0%}'.format((montante - 10000) / 10000)}", fg='green', bold=True)
-  return montante
+  if (not display): return
 
-  # # Beautifully plots the result on the screen
-  # pf.create_full_tear_sheet(carteira['retorno'], benchmark_rets=retorno['^BVSP'])
+  # Beautifully plots the result on the screen
+  pf.create_returns_tear_sheet(carteira['retorno'], benchmark_rets=retorno['^BVSP'])
 
 # Calculate Ibovespa return with R$ 1,000.00 invested
 def bovespa(start, end=time.strftime("%Y-%m-%d")):

--- a/shell_scripts/automate_backests.sh
+++ b/shell_scripts/automate_backests.sh
@@ -1,3 +1,6 @@
+# This file is intended to automate the back test and...
+# * Get the final result of the backtest
+
 # Run backtests on Brazilian Bovespa Stocks
 run_backtests() {
   ttab {cd /Users/victor/Desktop/python/bovespa-winner; python3 graham.py '{ "year": 2008 }'}

--- a/shell_scripts/backtest_plots.sh
+++ b/shell_scripts/backtest_plots.sh
@@ -1,0 +1,171 @@
+# This file is intended to automate the back test and...
+# * Get the plot graph of the backtest
+
+python3
+
+import sys, os
+sys.path.extend([f'./{name}' for name in os.listdir(".") if os.path.isdir(name)])
+
+import fundamentus
+import backtest
+
+
+#####################
+## Benjamin Graham ##
+#####################
+graham_2008 = ['ELET6', 'BRGE6', 'CPLE3', 'CPLE6', 'CSMG3', 'BRGE7', 'BRGE8', 'BRGE12', 'BRGE3', 'SAPR4']
+backtest.run(start=fundamentus.start_date(2008), tickers=graham_2008, display=True)
+
+graham_2009 = ['FESA4', 'CSMG3', 'USIM3', 'BRAP3', 'PEAB3', 'PEAB4', 'SAPR4', 'PATI4', 'CPLE3', 'CPLE6']
+backtest.run(start=fundamentus.start_date(2009), tickers=graham_2009, display=True)
+
+graham_2010 = ['CSMG3', 'EQTL3', 'CTSA4', 'CTSA3', 'SBSP3', 'BRGE3', 'BRGE6', 'BSLI3', 'BGIP3', 'BGIP4']
+backtest.run(start=fundamentus.start_date(2010), tickers=graham_2010, display=True)
+
+graham_2011 = ['BMEB4', 'BMEB3', 'BSLI3', 'WHRL3', 'WHRL4', 'ELET3', 'CTSA3', 'CTSA4', 'CSMG3', 'SBSP3']
+backtest.run(start=fundamentus.start_date(2011), tickers=graham_2011, display=True)
+
+graham_2012 = ['CPLE3', 'BBAS3', 'PETR4', 'RAPT3', 'VALE3', 'CMIG3', 'ECPR3', 'ECPR4', 'CTSA3', 'CTSA4']
+backtest.run(start=fundamentus.start_date(2012), tickers=graham_2012, display=True)
+
+graham_2013 = ['DOHL4', 'CTSA4', 'CESP3', 'CTSA3', 'BRSR3', 'BBAS3', 'CMIG3', 'BNBR3', 'CMIG4', 'VALE3']
+backtest.run(start=fundamentus.start_date(2013), tickers=graham_2013, display=True)
+
+graham_2014 = ['BBAS3', 'BNBR3', 'SOND6', 'SOND5', 'CTSA3', 'CTSA4', 'CMIG4', 'CMIG3', 'BRSR3', 'SAPR4']
+backtest.run(start=fundamentus.start_date(2014), tickers=graham_2014, display=True)
+
+graham_2015 = ['EZTC3', 'EVEN3', 'DOHL4', 'MRVE3', 'SAPR4', 'CMIG4', 'CMIG3', 'VIVT3', 'ETER3', 'BRSR3']
+backtest.run(start=fundamentus.start_date(2015), tickers=graham_2015, display=True)
+
+graham_2016 = ['ITSA4', 'ITSA3', 'ITUB3', 'CMIG4', 'CMIG3', 'BBAS3', 'CGRA4', 'CGRA3', 'EZTC3', 'TAEE11']
+backtest.run(start=fundamentus.start_date(2016), tickers=graham_2016, display=True)
+
+graham_2017 = ['TRPL3', 'TRPL4', 'BNBR3', 'BSLI4', 'CGRA3', 'CGRA4', 'BMIN4', 'SAPR3', 'BEES3', 'BEES4']
+backtest.run(start=fundamentus.start_date(2017), tickers=graham_2017, display=True)
+
+graham_2018 = ['BNBR3', 'TRPL3', 'TRPL4', 'ABCB4', 'BEES3', 'BEES4', 'CCPR3', 'SAPR4', 'FESA3', 'FESA4']
+backtest.run(start=fundamentus.start_date(2018), tickers=graham_2018, display=True)
+
+graham_2019 = ['FESA4', 'TRPL3', 'TRPL4', 'BNBR3', 'BPAR3', 'FESA3', 'MRVE3', 'VIVT3', 'BRSR3', 'NAFG3']
+backtest.run(start=fundamentus.start_date(2019), tickers=graham_2019, display=True)
+
+
+#################
+## Décio Bazin ##
+#################
+bazin_2008 = ['CSAB3', 'CSAB4', 'SULT3', 'SULT4', 'TRPL3', 'TRPL4', 'VIVT3', 'VIVT4', 'GRND3', 'SANB4']
+backtest.run(start=fundamentus.start_date(2008), tickers=bazin_2008, display=True)
+
+bazin_2009 = ['GRND3', 'FESA4', 'LREN3', 'PATI4', 'POSI3', 'ETER3', 'SOND3', 'IGTA3', 'TKNO4', 'POMO3']
+backtest.run(start=fundamentus.start_date(2009), tickers=bazin_2009, display=True)
+
+bazin_2010 = ['CTSA4', 'JHSF3', 'PEAB4', 'PEAB3', 'WHRL4', 'WHRL3', 'CRIV4', 'CTSA3', 'BGIP4', 'EKTR4']
+backtest.run(start=fundamentus.start_date(2010), tickers=bazin_2010, display=True)
+
+bazin_2011 = ['WHRL3', 'WHRL4', 'ODPV3', 'SOND3', 'ELET3', 'BGIP4', 'PATI4', 'ETER3', 'CSAB3', 'CSAB4']
+backtest.run(start=fundamentus.start_date(2011), tickers=bazin_2011, display=True)
+
+bazin_2012 = ['PATI4', 'GRND3', 'MERC4', 'ETER3', 'CGRA3', 'CGRA4', 'BGIP4', 'BGIP3', 'NAFG4', 'BBAS3']
+backtest.run(start=fundamentus.start_date(2012), tickers=bazin_2012, display=True)
+
+bazin_2013 = ['PATI4', 'ETER3', 'BGIP3', 'BGIP4', 'BEES4', 'WHRL4', 'WHRL3', 'GRND3', 'CMIG3', 'BRIV4']
+backtest.run(start=fundamentus.start_date(2013), tickers=bazin_2013, display=True)
+
+bazin_2014 = ['BRIV4', 'PINE4', 'BBAS3', 'GUAR3', 'WHRL4', 'ELET3', 'WHRL3', 'ENGI4', 'ENGI3', 'CRIV4']
+backtest.run(start=fundamentus.start_date(2014), tickers=bazin_2014, display=True)
+
+bazin_2015 = ['CRIV4', 'PINE4', 'SAPR4', 'BBAS3', 'BEES4', 'BEES3', 'DOHL4', 'WHRL4', 'WHRL3', 'BMEB4']
+backtest.run(start=fundamentus.start_date(2015), tickers=bazin_2015, display=True)
+
+bazin_2016 = ['BBSE3', 'CRIV4', 'ITSA4', 'BRIV4', 'ITSA3', 'FESA4', 'BBAS3', 'CGRA4', 'CGRA3', 'EZTC3']
+backtest.run(start=fundamentus.start_date(2016), tickers=bazin_2016, display=True)
+
+bazin_2017 = ['CRIV4', 'BRIV4', 'ITSA4', 'FESA4', 'CGRA4', 'CGRA3', 'BMEB4', 'AFLT3', 'MERC4', 'LCAM3']
+backtest.run(start=fundamentus.start_date(2017), tickers=bazin_2017, display=True)
+
+bazin_2018 = ['CRIV4', 'BRIV4', 'HGTX3', 'CGRA4', 'CGRA3', 'CSAB4', 'CSAB3', 'BMEB4', 'AFLT3', 'TRIS3']
+backtest.run(start=fundamentus.start_date(2018), tickers=bazin_2018, display=True)
+
+bazin_2019 = ['CRIV4', 'BRIV4', 'ITSA4', 'ITSA3', 'ITUB3', 'BBSE3', 'BMEB4', 'PTNT4', 'TRIS3', 'GRND3']
+backtest.run(start=fundamentus.start_date(2019), tickers=bazin_2019, display=True)
+
+
+#####################
+## Joel Greenblatt ##
+##   ROE + ROIC    ##
+#####################
+greenblatt_2008 = ['CEBR5', 'CEBR6', 'CEBR3', 'CEEB3', 'ENGI4', 'ENGI3', 'FBMC4', 'TIET4', 'VIVT4', 'WHRL3']
+backtest.run(start=fundamentus.start_date(2008), tickers=greenblatt_2008, display=True)
+
+greenblatt_2009 = ['FESA4', 'CEBR6', 'CEBR3', 'CEBR5', 'GGBR4', 'MYPK3', 'FBMC4', 'RAPT3', 'RAPT4', 'LPSB3']
+backtest.run(start=fundamentus.start_date(2009), tickers=greenblatt_2009, display=True)
+
+greenblatt_2010 = ['TIET3', 'TIET4', 'ETER3', 'EKTR4', 'SCAR3', 'SOND5', 'SOND6', 'GRND3', 'CGAS3', 'WEGE3']
+backtest.run(start=fundamentus.start_date(2010), tickers=greenblatt_2010, display=True)
+
+greenblatt_2011 = ['COCE3', 'COCE5', 'CEEB5', 'WHRL3', 'CAMB4', 'CIEL3', 'TIET3', 'CGAS3', 'WHRL4', 'CEEB3']
+backtest.run(start=fundamentus.start_date(2011), tickers=greenblatt_2011, display=True)
+
+greenblatt_2012 = ['AELP3', 'FHER3', 'VALE5', 'VALE3', 'COCE3', 'COCE5', 'RAPT3', 'CSNA3', 'RAPT4', 'TAEE11']
+backtest.run(start=fundamentus.start_date(2012), tickers=greenblatt_2012, display=True)
+
+greenblatt_2013 = ['WHRL3', 'WHRL4', 'TIET3', 'TIET4', 'ETER3', 'CSRN5', 'COCE5', 'COCE3', 'CMIG3', 'TRPL4']
+backtest.run(start=fundamentus.start_date(2013), tickers=greenblatt_2013, display=True)
+
+greenblatt_2014 = ['SOND5', 'BAUH4', 'WHRL3', 'WHRL4', 'TIET3', 'TIET4', 'ETER3', 'CMIG4', 'CMIG3', 'PTBL3']
+backtest.run(start=fundamentus.start_date(2014), tickers=greenblatt_2014, display=True)
+
+greenblatt_2015 = ['OGXP3', 'WHRL3', 'WHRL4', 'VVAR3', 'TIET3', 'CMIG4', 'PSSA3', 'CMIG3', 'TIET4', 'PTBL3']
+backtest.run(start=fundamentus.start_date(2015), tickers=greenblatt_2015, display=True)
+
+greenblatt_2016 = ['AGRO3', 'PTBL3', 'CMIG4', 'CMIG3', 'SEER3', 'BRKM3', 'EQTL3', 'COCE5', 'PMAM3', 'VVAR3']
+backtest.run(start=fundamentus.start_date(2016), tickers=greenblatt_2016, display=True)
+
+greenblatt_2017 = ['TRPL3', 'TRPL4', 'MSPA4', 'CGAS3', 'CGAS5', 'BAUH4', 'BRKM3', 'BRKM5', 'BEEF3', 'SMLS3']
+backtest.run(start=fundamentus.start_date(2017), tickers=greenblatt_2017, display=True)
+
+greenblatt_2018 = ['IDNT3', 'BAUH4', 'UNIP6', 'UNIP5', 'UNIP3', 'WIZS3', 'PSSA3', 'CRPG6', 'FESA4', 'CRPG5']
+backtest.run(start=fundamentus.start_date(2018), tickers=greenblatt_2018, display=True)
+
+greenblatt_2019 = ['WIZS3', 'UNIP6', 'UNIP5', 'UNIP3', 'CRPG6', 'CRPG5', 'AGRO3', 'SMLS3', 'CIEL3', 'BAUH4']
+backtest.run(start=fundamentus.start_date(2019), tickers=greenblatt_2019, display=True)
+
+
+###################
+#### Piotroski ####
+###################
+piotroski_2008 = ['BMIN4', 'BMIN3', 'BAZA3', 'SAPR4', 'CRIV4', 'CRIV3', 'ETER3', 'JBSS3', 'MERC4', 'ITSA4']
+backtest.run(start=fundamentus.start_date(2008), tickers=piotroski_2008, display=True)
+
+piotroski_2009 = ['BBRK3', 'LAME3', 'LAME4', 'MULT3', 'BBDC3', 'COCE3', 'BBDC4', 'COCE6', 'COCE5', 'ELET6']
+backtest.run(start=fundamentus.start_date(2009), tickers=piotroski_2009, display=True)
+
+piotroski_2010 = ['BAZA3', 'SPRI3', 'KLBN4', 'KLBN3', 'ELEK4', 'TGMA3', 'ELEK3', 'RANI3', 'RANI4', 'MYPK3']
+backtest.run(start=fundamentus.start_date(2010), tickers=piotroski_2010, display=True)
+
+piotroski_2011 = ['TCNO4', 'TCNO3', 'FHER3', 'CESP3', 'EKTR4', 'CESP5', 'SMTO3', 'EKTR3', 'CESP6', 'CEDO4']
+backtest.run(start=fundamentus.start_date(2011), tickers=piotroski_2011, display=True)
+
+piotroski_2012 = ['MTSA4', 'TOTS3', 'KEPL3', 'UNIP6', 'UNIP3', 'UNIP5', 'DTCY3', 'CBEE3', 'CTSA3', 'CTSA4']
+backtest.run(start=fundamentus.start_date(2012), tickers=piotroski_2012, display=True)
+
+piotroski_2013 = ['SHUL4', 'VVAR3', 'CLSC4', 'CLSC3', 'BRFS3', 'MNDL3', 'TXRX3', 'TRIS3', 'WHRL3', 'WHRL4']
+backtest.run(start=fundamentus.start_date(2013), tickers=piotroski_2013, display=True)
+
+piotroski_2014 = ['CESP3', 'CESP6', 'CESP5', 'MULT3', 'PTNT4', 'CARD3', 'JBSS3', 'NAFG4', 'HYPE3', 'CEPE5']
+backtest.run(start=fundamentus.start_date(2014), tickers=piotroski_2014, display=True)
+
+piotroski_2015 = ['CARD3', 'BMIN4', 'ENEV3', 'GFSA3', 'SHOW3', 'ENGI3', 'BRGE11', 'ENGI4', 'BRGE3', 'BRGE8']
+backtest.run(start=fundamentus.start_date(2015), tickers=piotroski_2015, display=True)
+
+piotroski_2016 = ['VULC3', 'FRIO3', 'CARD3', 'SEER3', 'ALUP11', 'MDIA3', 'MGEL4', 'LOGN3', 'SAPR4', 'SAPR3']
+backtest.run(start=fundamentus.start_date(2016), tickers=piotroski_2016, display=True)
+
+piotroski_2017 = ['VULC3', 'MTSA4', 'NAFG4', 'ENEV3', 'ANIM3', 'NAFG3', 'TEND3', 'YDUQ3', 'SLCE3', 'IGTA3']
+backtest.run(start=fundamentus.start_date(2017), tickers=piotroski_2017, display=True)
+
+piotroski_2018 = ['CESP3', 'WIZS3', 'LAME3', 'CESP6', 'CPRE3', 'CRFB3', 'LAME4', 'VLID3', 'TUPY3', 'TEND3']
+backtest.run(start=fundamentus.start_date(2018), tickers=piotroski_2018, display=True)
+
+piotroski_2019 = ['BEEF3', 'EVEN3', 'RAPT3', 'RAPT4', 'KEPL3', 'WEGE3', 'BAZA3', 'CPLE3', 'CPLE6', 'CSMG3']
+backtest.run(start=fundamentus.start_date(2019), tickers=piotroski_2019, display=True)


### PR DESCRIPTION
# Description ✍️

This PR implements a feature on `backtest.run()` method to generate and display a plot graph for backtesting purposes using the `pyfolio` lib.

Now, the `run()` function has a new parameter called `display`. When it is set to `True`, the `run()` will display the backtest plot graph on the end.

⚠️ For now, I don't know why, but the plot graphs are being all together and smashed.
I opened a ticket for this problem here => https://github.com/quantopian/pyfolio/issues/659


# Overview 🔍

![backtesting_graph](https://user-images.githubusercontent.com/7637806/97119211-74f1dc80-16ed-11eb-8d36-a586fe18f9be.png)


# Checks ☑️

- [x] Add display to backtest.run() method. If it is True, the backtest will show a plot graph
- [x] Add backtest_plots.sh file
- [x] Add Pull Request Template
